### PR TITLE
fix: corrigir responsividade do botão "Criar Perfil" em mobile

### DIFF
--- a/frontend/src/app/pages/login/login.component.css
+++ b/frontend/src/app/pages/login/login.component.css
@@ -391,17 +391,44 @@
     .login-card { max-width: 360px; }
     .modal-card { padding: 1rem; }
     
+    /* Ajustar container dos botões para mobile */
+    .form-actions {
+        gap: .6rem !important; /* Reduz espaço entre botões */
+        flex-wrap: nowrap; /* Evita quebra de linha dos botões */
+    }
+    
     /* Ajustar largura do botão para mobile para acomodar "Criar Perfil" */
     .modal .btn-gradient {
-        width: 140px !important; /* Aumenta largura para acomodar o texto */
-        font-size: 0.9rem; /* Reduz ligeiramente o tamanho da fonte */
-        padding: .5rem 1rem; /* Ajusta o padding */
+        width: 160px !important; /* Aumenta ainda mais para garantir espaço */
+        min-width: 160px !important; /* Garante largura mínima */
+        font-size: 0.85rem; /* Fonte menor para caber melhor */
+        padding: .5rem .8rem; /* Padding ajustado */
+        white-space: nowrap !important; /* Força uma linha */
     }
     
     .modal .btn-secondary {
-        width: 140px !important; /* Mantém ambos botões do mesmo tamanho */
-        font-size: 0.9rem;
-        padding: .5rem 1rem;
+        width: 160px !important; /* Mantém ambos botões do mesmo tamanho */
+        min-width: 160px !important;
+        font-size: 0.85rem;
+        padding: .5rem .8rem;
+        white-space: nowrap !important;
+    }
+}
+
+/* Para telas pequenas (entre 321px e 400px) */
+@media (max-width: 400px) {
+    .modal .btn-gradient,
+    .modal .btn-secondary {
+        width: 150px !important;
+        min-width: 150px !important;
+        font-size: 0.8rem !important;
+        padding: .4rem .6rem !important;
+        white-space: nowrap !important;
+    }
+    
+    .form-actions {
+        gap: .4rem !important;
+        flex-wrap: nowrap !important;
     }
 }
 
@@ -409,14 +436,35 @@
 @media (max-width: 320px) {
     .modal .btn-gradient,
     .modal .btn-secondary {
-        width: 130px !important; /* Largura menor para telas muito pequenas */
-        font-size: 0.85rem; /* Fonte ainda menor */
-        padding: .4rem .8rem; /* Padding reduzido */
-        white-space: nowrap; /* Força texto em uma linha */
+        width: 140px !important; /* Largura ajustada para telas muito pequenas */
+        min-width: 140px !important;
+        font-size: 0.75rem !important; /* Fonte bem menor */
+        padding: .4rem .5rem !important; /* Padding bem reduzido */
+        white-space: nowrap !important; /* Força texto em uma linha */
+        line-height: 1.2 !important; /* Ajusta altura da linha */
     }
     
     .form-actions {
-        gap: .5rem; /* Reduz o espaçamento entre botões */
+        gap: .3rem !important; /* Espaçamento mínimo entre botões */
+        flex-wrap: nowrap !important;
+    }
+    
+    .modal-content {
+        width: 98% !important; /* Usa quase toda a largura da tela */
+    }
+}
+
+/* Override global styles for mobile specifically for modal buttons */
+@media (max-width: 430px) {
+    .modal .btn-gradient,
+    .modal .btn-secondary {
+        padding: .5rem .8rem !important; /* Override global mobile padding */
+        font-size: 0.8rem !important; /* Override global mobile font-size */
+        min-height: 48px !important; /* Override global mobile min-height */
+        width: 145px !important; /* Largura suficiente para "Criar Perfil" */
+        white-space: nowrap !important;
+        text-overflow: ellipsis !important;
+        overflow: hidden !important;
     }
 }
 
@@ -477,13 +525,18 @@
     height: 50px !important;
     border: 0;
     border-radius: 999px;
-    padding: .5rem 1.6rem;
+    padding: .5rem 1.6rem !important;
     background: #f3f4f6;
     color: #0f2238;
     font-weight: 700;
     box-shadow: 0 14px 30px rgba(90,141,255,0.06);
     cursor: pointer;
     transition: transform .2s ease, box-shadow .2s ease;
+    white-space: nowrap !important; /* Evita quebra de linha */
+    overflow: hidden; /* Oculta texto que não cabe */
+    text-overflow: ellipsis; /* Adiciona ... se necessário */
+    font-size: 1rem !important; /* Override global mobile styles */
+    min-height: 50px !important; /* Override global min-height */
 }
 
 .modal .btn-secondary:hover {
@@ -512,13 +565,18 @@
     height: 50px !important;
     border: 0;
     border-radius: 999px;
-    padding: .5rem 1.6rem;
+    padding: .5rem 1.6rem !important;
     background: linear-gradient(90deg, #ff5fa3 0%, #5a8dff 100%);
     color: #fff;
     font-weight: 700;
     box-shadow: 0 8px 18px rgba(111,96,255,0.12);
     cursor: pointer;
     transition: transform .2s ease, box-shadow .2s ease;
+    white-space: nowrap !important; /* Evita quebra de linha */
+    overflow: hidden; /* Oculta texto que não cabe */
+    text-overflow: ellipsis; /* Adiciona ... se necessário */
+    font-size: 1rem !important; /* Override global mobile styles */
+    min-height: 50px !important; /* Override global min-height */
 }
 
 .modal .btn-gradient:hover {


### PR DESCRIPTION
- Aumentar largura dos botões do modal para acomodar texto completo
- Adicionar white-space: nowrap para evitar quebra de linha
- Implementar media queries escalonadas (480px, 400px, 320px, 430px)
- Override estilos globais que causavam conflito em mobile
- Ajustar padding e font-size progressivamente para telas menores

Resolves: Texto "Criar Perfil" quebrava em duas linhas no mobile